### PR TITLE
Add naming spike

### DIFF
--- a/lib/naming_normalizers/base.rb
+++ b/lib/naming_normalizers/base.rb
@@ -1,0 +1,55 @@
+module NamingNormalizers
+  class Base < Parser::TreeRewriter
+    include Mandate
+
+    def initialize(code)
+      @code = code
+      @mapping = {}
+    end
+
+    def call
+      buffer = Parser::Source::Buffer.new('', source: code)
+      builder = RuboCop::AST::Builder.new
+      ast = Parser::CurrentRuby.new(builder).parse(buffer)
+      rewrite(buffer, ast)
+    end
+
+    def on_op_asgn(node)
+      # p "opasgn"
+      #node.pry
+      super
+    end
+
+    def on_casgn(node)
+      # p "casgn"
+      #node.pry
+      super
+    end
+
+    def on_defs(node)
+      # p "defs"
+      #node.pry
+      super
+    end
+
+    def on_numblock(node)
+      # p "numblock"
+      #node.pry
+      super
+    end
+
+    def handler_missing(node)
+      case node.type
+      # noop
+      when true, :str, :nil, :int
+        super
+      else
+        p "handler_missing"
+        #node.pry
+      end
+    end
+
+    private
+    attr_reader :code, :mapping
+  end
+end

--- a/lib/naming_normalizers/method_locals.rb
+++ b/lib/naming_normalizers/method_locals.rb
@@ -1,0 +1,60 @@
+module NamingNormalizers
+  class MethodLocals < Base
+
+    def initialize(code)
+      super(code)
+
+      @method_name = nil
+      @methods_vars = {}
+    end
+
+    %i[
+      on_argument
+      on_const
+      on_var
+      on_vasgn
+    ].each do |method_name|
+      define_method method_name do |node|
+        replace_loc_name(node)
+        super(node)
+      end
+    end
+
+    def on_def(node)
+      @method_name = node.loc.name.source
+      @methods_vars[@method_name] = {}
+
+      super(node)
+    end
+
+    def on_end(node)
+      node.pry
+    end
+
+    def handler_missing(node)
+      super(node)
+    end
+
+    def replace_loc_name(node)
+      replace(node.loc.name, placeholder_for(node.loc.name.source))
+    end
+
+    def replace_loc_selector(node)
+      replace(node.loc.selector, placeholder_for(node.loc.selector.source))
+    end
+
+    def placeholder_for(token)
+      # Return if we're outside of a method
+      return token unless instance_variable_defined?("@method_name") && @method_name
+
+      # Get the vars for this method_naem
+      meth_vars = @methods_vars[@method_name]
+
+      # Return if we have one
+      return meth_vars[token] if meth_vars.key?(token)
+        
+      # Else get out of here
+      meth_vars[token] = "#{@method_name}_#{meth_vars.length}"
+    end
+  end
+end

--- a/lib/normalizers/method_internal_naming_normalising.rb
+++ b/lib/normalizers/method_internal_naming_normalising.rb
@@ -1,7 +1,7 @@
 require 'parser/current'
 
 # class Normalize < Parser::AST::Processor
-class NamingNormalizer < Parser::TreeRewriter
+class NamingNormalizers::MethodInternals < Parser::TreeRewriter
   include Mandate
 
   def initialize(code, mapping)
@@ -47,6 +47,7 @@ class NamingNormalizer < Parser::TreeRewriter
   end
 
   def process_regular_node
+    p "HERE?"
     super
   end
 
@@ -110,3 +111,4 @@ class NamingNormalizer < Parser::TreeRewriter
     mapping.key?(key) ? mapping[key] : key
   end
 end
+

--- a/lib/representer.rb
+++ b/lib/representer.rb
@@ -4,6 +4,8 @@ require 'rubocop'
 require 'parser/current'
 require 'pathname'
 
+require_relative 'naming_normalizers/base'
+require_relative 'naming_normalizers/method_locals'
 require_relative 'normalizers/naming_normalizer'
 
 require_relative 'generate_mapping'
@@ -11,7 +13,7 @@ require_relative 'generate_mapping'
 require_relative 'representation'
 require_relative 'represent_solution'
 
-#require 'pry'
+require 'pry'
 
 module Representer
   def self.generate(exercise_slug, solution_path, output_path)

--- a/test/naming_normalizers/method_locals.rb
+++ b/test/naming_normalizers/method_locals.rb
@@ -1,0 +1,176 @@
+require "test_helper"
+
+class NamingNormalizers::MethodLocalsTest < Minitest::Test
+  def test_variable_name_outside_of_method
+    assert_noop("foobar = true")
+  end
+
+  def test_local_variable
+    assert_rewritten(
+      "def foo
+        foobar = true
+        foobar = false
+        barfoo = 1
+      end",
+
+      "def foo
+        foo_0 = true
+        foo_0 = false
+        foo_1 = 1
+      end"
+    )
+  end
+
+  def test_local_variable_being_used
+    assert_rewritten(
+      "def foo
+        foobar = true
+        puts(foobar)
+      end",
+
+      "def foo
+        foo_0 = true
+        puts(foo_0)
+      end"
+    )
+  end
+
+  def test_two_methods
+    assert_rewritten(
+      "def foo
+        foobar = true
+        puts(foobar)
+      end
+      
+      def bar
+        foobar = true
+        puts(foobar)
+      end",
+
+      "def foo
+        foo_0 = true
+        puts(foo_0)
+      end
+      
+      def bar
+        bar_0 = true
+        puts(bar_0)
+      end"
+    )
+  end
+
+  def test_arg
+    assert_rewritten(
+      "def foo(foobar)
+        foobar = true
+        puts(foobar)
+      end",
+
+      "def foo(foo_0)
+        foo_0 = true
+        puts(foo_0)
+      end"
+    )
+  end
+
+
+
+
+#   def test_class_name
+#     code = "class Foobar; end"
+#     representation = "class Foobar; end"
+#     assert_rewritten code, representation
+#   end
+
+#   def test_method_name
+#     code = "def foobar; end"
+#     representation = "def foobar; end"
+#     assert_rewritten code, representation
+#   end
+
+#   def test_if
+#     code = "foo = true; if foo then 'bar' else nil end"
+#     representation = "placeholder_0 = true; if placeholder_0 then 'bar' else nil end"
+#     assert_rewritten code, representation
+#   end
+
+#   def test_return
+#     code = "foo = true; return foo"
+#     representation = "placeholder_0 = true; return placeholder_0"
+#     assert_rewritten code, representation
+#   end
+
+#   def test_method_call
+#     code = '
+#       def bar; end
+#       foo.bar
+#     '
+#     representation = '
+#       def placeholder_0; end
+#       foo.placeholder_0
+#     '
+#     assert_rewritten code, representation
+#   end
+
+#   def test_non_defined_method_call
+#     code = "foo = []; foo.each"
+#     representation = "placeholder_0 = []; placeholder_0.each"
+#     assert_rewritten code, representation
+#   end
+
+#   def test_args
+#     code = %{
+#       foo = 1
+#       bar = 2
+#       def somefunc(param1, bar)
+#         return param1 + bar
+#       end
+#     }
+#     representation = %{
+#       placeholder_0 = 1
+#       placeholder_1 = 2
+#       def placeholder_2(placeholder_3, placeholder_1)
+#         return placeholder_3 + placeholder_1
+#       end
+#     }
+#     assert_rewritten code, representation
+#   end
+
+#   def test_complex_example
+#     code = '
+#       class TwoFer
+#         def two_fer
+#           "foo"
+#         end
+
+#         def foobar
+#           two_fer = "cat"
+#           return TwoFer.two_fer
+#         end
+#       end
+#     '
+#     representation = '
+#       class PLACEHOLDER_0
+#         def placeholder_1
+#           "foo"
+#         end
+
+#         def placeholder_2
+#           placeholder_1 = "cat"
+#           return PLACEHOLDER_0.placeholder_1
+#         end
+#       end
+#     '
+#     assert_rewritten(code, representation)
+#   end
+
+  def assert_noop(code)
+    assert_rewritten(code, code)
+  end
+
+  def assert_rewritten(code, expected)
+    actual = NamingNormalizers::MethodLocals.(code)
+    assert_equal expected.strip, actual.strip
+  end
+end
+

--- a/test/sanity_test.rb
+++ b/test/sanity_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+# The purpose of these tests it to ensure that things
+# can actually work in reality rather than just in theory,
+# that feedback can be sensibly given. It is a sanity check
+# for the whole process of representing as much as just this
+# Ruby representer.
+
+class SanityTest < Minitest::Test
+  def test_1
+    code_1 = <<-CODE
+      def add_2(a)
+        a + 2
+      end
+
+      def add_3(a)
+        a + 3
+      end
+    CODE
+
+    code_2 = <<-CODE
+      def add_2(a)
+        a + 2
+      end
+
+      def add_3(b)
+        b + 3
+      end
+    CODE
+
+    code_3 = <<-CODE
+      def add_2(b)
+        b + 2
+      end
+
+      def add_3(b)
+        b + 3
+      end
+    CODE
+
+    representation_1 = Representation.new(code_1)
+    representation_1.normalize!
+
+    representation_2 = Representation.new(code_2)
+    representation_2.normalize!
+
+    representation_3 = Representation.new(code_3)
+    representation_3.normalize!
+
+    assert_equal representation_1.ast, representation_2.ast
+    assert_equal representation_1.ast, representation_3.ast
+  end
+end
+
+#   def test_1
+#     code_1 = <<-CODE
+#       foobar = "This is nice"
+
+#       def add_2(a)
+#         a + 2
+#       end
+
+#       def add_3(a)
+#         a + 3
+#       end
+
+#       class TwoFer
+#         def two_fer
+#           "foo"
+#         end
+
+#         def foobar
+#           two_fer = "cat"
+#           return TwoFer.two_fer
+#         end
+#       end
+#     CODE
+
+#     code_2 = <<-CODE
+#       something = "This is nice"
+
+#       class TwoFer
+#         def two_fer
+#           "foo"
+#         end
+
+#         def foobar
+#           mouse = "cat"
+#           return TwoFer.two_fer
+#         end
+#       end
+#     CODE
+
+#     representation = Representation.new(code)
+#     representation.normalize!
+
+#     # Let's give feedback on the first
+
+#     """
+#     """


### PR DESCRIPTION
_This is a messy silly spike. The code is not important but the idea is._

_Also - this is entirely not urgent or important, but as writing CSS 24/7 is killing me, and its important to be confident of our specs before launch, I felt like spending an hour or two reasoning about this using code_

---

This explores the idea of rewriting a solution to standardise variable naming to allow for deeper normalisation. 

## Problem

It is essential that when a mentor gives feedback on a representer solution that they are referencing identifiers (e.g. variable names) that can be replaced with other variable names in other solutions.

Right now the fact that someone can reuse an identifier (e.g. variable name) in different contexts is problematic for us. 

Take these three submissions:

```ruby
# Submission 1
def add_2(a); a + 2; end
def add_3(a); a + 3; end
```

```ruby
# Submission 2
def add_2(b); b + 2; end
def add_3(b); b + 3; end
```

```ruby
# Submission 3
def add_2(a); a + 2; end
def add_3(b); b + 3; end
```

If we replace `a` in the first solution with `PLACEHOLDER_1` and `b` in the second with `PLACEHOLDER_1` we can see that they are identical. However in submission 3 because both `a` and `b` are used, this naive replacement means they get different representations.

## Possible Solution

Rather than relying on the identifiers given by the student we could instead rename the variables ourselves internally. This would give us something like this:

```ruby
# Normalised
def add_2(add_2_0); add_2_0 + 2; end
def add_3(add_3_0); add_3_0 + 3; end
```

All three submissions are normalised in the same way so their representations are identical. This branch achieves this (see test/naming_normalizers/method_locals.rb for tests):

This still gives us a problem though that we show the original code to the mentor to give feedback on. If they gave feedback on submission 3, this would be fine, but on submissions 1 or 2, the `a` or `b` would be ambiguous. The rule to guard against this is that all `mapping.json` files must be reversible (ie we cannot have identical keys or values).

To fix this, we could return our normalised solution as a new `normalized.rb` file with a mapping against **this** file, and show this normalised code to the mentor (possibly with a tab to see original code too in case the modified identifiers make it hard to read). Regardless of which of the three submissions are used, things would then map correctly.

---

- Note 1: This spike only works with very limited situation atm (local variables inside methods). However, I think this acutally fixes the vast majority of problems.
- Note 2: Choosing readable identifiers will be important
- Note 3: Rewriting code is relatively easy in Ruby and in many other languages. However, there are some that it would be hard in. For those, as long as we can get line/character numbers (which seems to be pretty universal) then we can text-replace things, making this also feasible.
- Note 4: If we do this, it'll be post-v3.
- Note 5: This will be an enhancement to the existing spec. Old representers will continue to work.
- Note 6: This is basically impossible to do accurately in Ruby. The moment someone uses certain metaprogramming techniques, this will fall apart. We need to determine if those techniques mean we may give out the wrong feedback, or if they just always make their solutions unique. We can mitigate against either by guarding against certain techniques (such as `send` and `define_method` and either falling back to a more naive implementation or returning an error on those.