### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 test/
 scripts/
 node_modules/
+.appends

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ test/
 scripts/
 node_modules/
 .appends
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ node_modules/
 .appends
 .git
 .github
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ node_modules/
 .gitignore
 .gitattributes
 .dockerignore
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ node_modules/
 .github
 .gitignore
 .gitattributes
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ scripts/
 node_modules/
 .appends
 .git
+.github

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ node_modules/
 .git
 .github
 .gitignore
+.gitattributes


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
