### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
-FROM ruby:2.6.6-alpine3.13
+FROM ruby:2.6.6-alpine3.13 AS build
 
 RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh build-base gcc wget git
+    apk add --no-cache git openssh build-base gcc wget git
 
 RUN gem install bundler -v 2.3.6
-
-WORKDIR /opt/representer
 
 COPY Gemfile Gemfile.lock .
 
 RUN bundle install
+
+FROM ruby:2.6.6-alpine3.13 AS runtime
+
+RUN apk add --no-cache bash
+
+WORKDIR /opt/representer
+
+COPY --from=build /usr/local/bundle /usr/local/bundle
 
 COPY . .
 


### PR DESCRIPTION
This PR builds on #40 and reduces the size of the image from 314MB to 75.2MB