### PR TITLE
Don't rely on filename for config reads

### DIFF
--- a/lib/represent_solution.rb
+++ b/lib/represent_solution.rb
@@ -1,10 +1,11 @@
+require 'json'
+
 class RepresentSolution
   include Mandate
 
   initialize_with :exercise_slug, :solution_path, :output_path
 
   def call
-    code = File.read(solution_path / "#{exercise_slug.tr('-', '_')}.rb")
     representation = Representation.new(code)
     representation.normalize!
 
@@ -15,5 +16,16 @@ class RepresentSolution
     File.open(output_path / "mapping.json", "w") do |f|
       f.write(representation.mapping.to_json)
     end
+  end
+
+  memoize
+  def code
+    filenames.map { |filename| File.read(solution_path / filename) }.join(" ")
+  end
+
+  memoize
+  def filenames
+    config = JSON.parse(File.read(solution_path / '.meta' / 'config.json'))
+    config['files']['solution']
   end
 end

--- a/test/represent_solution_test.rb
+++ b/test/represent_solution_test.rb
@@ -11,7 +11,7 @@ class RepresentateSolutionTest < Minitest::Test
     representation.stubs(mapping:)
     representation.expects(:normalize!)
 
-    config = {files: { solution: [code_filepath] } }.to_json
+    config = { files: { solution: [code_filepath] } }.to_json
 
     Representation.expects(:new).with(code).returns(representation)
     File.expects(:read).with(SOLUTION_PATH / ".meta/config.json").returns(config)

--- a/test/represent_solution_test.rb
+++ b/test/represent_solution_test.rb
@@ -4,14 +4,19 @@ class RepresentateSolutionTest < Minitest::Test
   def test_extracts_and_writes_code_correctly
     code = "some code"
     ast = "some representation"
+    code_filepath = "foooooo.rb"
     mapping = { foo: 'bar' }
     representation = mock
     representation.stubs(ast:)
     representation.stubs(mapping:)
     representation.expects(:normalize!)
 
+    config = {files: { solution: [code_filepath] } }.to_json
+
     Representation.expects(:new).with(code).returns(representation)
-    File.expects(:read).with(SOLUTION_PATH / "two_fer.rb").returns(code)
+    File.expects(:read).with(SOLUTION_PATH / ".meta/config.json").returns(config)
+
+    File.expects(:read).with(SOLUTION_PATH / code_filepath).returns(code)
     writer = mock
     writer.expects(:write).with(ast)
     File.expects(:open).

--- a/test/representer_test.rb
+++ b/test/representer_test.rb
@@ -16,6 +16,9 @@ class RepresenterTest < Minitest::Test
 
   def test_e2e
     Dir.mktmpdir("code") do |dir|
+      Dir.mkdir("#{dir}/.meta")
+      File.write("#{dir}/.meta/config.json", {files: { solution: ['lasagna.rb'] } }.to_json)
+
       File.write("#{dir}/lasagna.rb", '
         class Lasagna
           EXPECTED_MINUTES_IN_OVEN = 40

--- a/test/representer_test.rb
+++ b/test/representer_test.rb
@@ -17,7 +17,7 @@ class RepresenterTest < Minitest::Test
   def test_e2e
     Dir.mktmpdir("code") do |dir|
       Dir.mkdir("#{dir}/.meta")
-      File.write("#{dir}/.meta/config.json", {files: { solution: ['lasagna.rb'] } }.to_json)
+      File.write("#{dir}/.meta/config.json", { files: { solution: ['lasagna.rb'] } }.to_json)
 
       File.write("#{dir}/lasagna.rb", '
         class Lasagna

--- a/tests/examples/basic/.meta/config.json
+++ b/tests/examples/basic/.meta/config.json
@@ -1,0 +1,1 @@
+{ "files": { "solution": ["basic.rb"] } }

--- a/tests/examples/lasagna/.meta/config.json
+++ b/tests/examples/lasagna/.meta/config.json
@@ -1,0 +1,2 @@
+{ "files": { "solution": ["lasagna.rb"] } }
+


### PR DESCRIPTION
The representer was still generating filenames, rather than reading them from config.